### PR TITLE
Add modal and devlooper to deployment

### DIFF
--- a/.github/workflows/build-containers-enterprise.yml
+++ b/.github/workflows/build-containers-enterprise.yml
@@ -85,3 +85,83 @@ jobs:
             ghcr.io/gitroomhq/postiz-app-enterprise:arm64-${{ env.CONTAINERVER }}
 
           docker manifest push ghcr.io/gitroomhq/postiz-app-enterprise:latest
+
+  build-modal-container:
+    needs: build-containers-common
+    strategy: 
+      matrix:
+        include:
+          - runnertags: ubuntu-latest
+            arch: amd64
+          - runnertags: [self-hosted, ARM64]
+            arch: arm64
+
+    runs-on: ${{ matrix.runnertags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: docker build
+        run: ./var/docker/docker-build.sh
+
+      - name: Print post-build debug info
+        run: |
+          docker images
+
+      - name: docker tag
+        env: 
+          CONTAINERVER: ${{ needs.build-containers-common.outputs.containerver }}
+        run: |
+          docker tag localhost/postiz-modal ghcr.io/gitroomhq/postiz-modal-enterprise:${{ matrix.arch }}-${{ env.CONTAINERVER }}
+          docker push ghcr.io/gitroomhq/postiz-modal-enterprise:${{ matrix.arch }}-${{ env.CONTAINERVER }}
+
+  build-devlooper-container:
+    needs: build-containers-common
+    strategy: 
+      matrix:
+        include:
+          - runnertags: ubuntu-latest
+            arch: amd64
+          - runnertags: [self-hosted, ARM64]
+            arch: arm64
+
+    runs-on: ${{ matrix.runnertags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: docker build
+        run: ./var/docker/docker-build.sh
+
+      - name: Print post-build debug info
+        run: |
+          docker images
+
+      - name: docker tag
+        env: 
+          CONTAINERVER: ${{ needs.build-containers-common.outputs.containerver }}
+        run: |
+          docker tag localhost/postiz-devlooper ghcr.io/gitroomhq/postiz-devlooper-enterprise:${{ matrix.arch }}-${{ env.CONTAINERVER }}
+          docker push ghcr.io/gitroomhq/postiz-devlooper-enterprise:${{ matrix.arch }}-${{ env.CONTAINERVER }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -83,3 +83,79 @@ jobs:
             ghcr.io/gitroomhq/postiz-app:arm64-${{ env.CONTAINERVER }}
 
           docker manifest push ghcr.io/gitroomhq/postiz-app:latest
+
+  build-modal-container:
+    needs: build-containers-common
+    strategy: 
+      matrix:
+        include:
+          - runnertags: ubuntu-latest
+            arch: amd64
+          - runnertags: [self-hosted, ARM64]
+            arch: arm64
+
+    runs-on: ${{ matrix.runnertags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: docker build
+        run: ./var/docker/docker-build.sh
+
+      - name: Print post-build debug info
+        run: |
+          docker images
+
+      - name: docker tag
+        env: 
+          CONTAINERVER: ${{ needs.build-containers-common.outputs.containerver }}
+        run: |
+          docker tag localhost/postiz-modal ghcr.io/gitroomhq/postiz-modal:${{ matrix.arch }}-${{ env.CONTAINERVER }}
+          docker push ghcr.io/gitroomhq/postiz-modal:${{ matrix.arch }}-${{ env.CONTAINERVER }}
+
+  build-devlooper-container:
+    needs: build-containers-common
+    strategy: 
+      matrix:
+        include:
+          - runnertags: ubuntu-latest
+            arch: amd64
+          - runnertags: [self-hosted, ARM64]
+            arch: arm64
+
+    runs-on: ${{ matrix.runnertags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: docker build
+        run: ./var/docker/docker-build.sh
+
+      - name: Print post-build debug info
+        run: |
+          docker images
+
+      - name: docker tag
+        env: 
+          CONTAINERVER: ${{ needs.build-containers-common.outputs.containerver }}
+        run: |
+          docker tag localhost/postiz-devlooper ghcr.io/gitroomhq/postiz-devlooper:${{ matrix.arch }}-${{ env.CONTAINERVER }}
+          docker push ghcr.io/gitroomhq/postiz-devlooper:${{ matrix.arch }}-${{ env.CONTAINERVER }}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,10 @@
-# This Dockerfile is used for producing 3 container images.
+# This Dockerfile is used for producing 5 container images.
 #
 # base - which is thrown away, that contains node and the basic infrastructure. 
 # devcontainer - which is used for development, and contains the source code and the node_modules.
 # dist - which is used for production, and contains the built source code and the node_modules.
+# modal - which is used for modal, and contains the built source code and the node_modules.
+# devlooper - which is used for devlooper, and contains the built source code and the node_modules.
 
 ARG NODE_VERSION="20.17"
 
@@ -76,3 +78,35 @@ VOLUME /uploads
 
 ## Labels at the bottom, because CI will eventually add dates, commit hashes, etc.
 LABEL org.opencontainers.image.title="Postiz App (Production)"
+
+# Modal image
+FROM base AS modal
+
+COPY --from=devcontainer /app/node_modules/ /app/node_modules/
+COPY --from=devcontainer /app/dist/ /app/dist/
+
+# Required for prisma
+COPY --from=devcontainer /app/libraries/ /app/libraries/
+
+COPY package.json nx.json /app/
+
+VOLUME /config
+VOLUME /uploads
+
+LABEL org.opencontainers.image.title="Postiz App (Modal)"
+
+# Devlooper image
+FROM base AS devlooper
+
+COPY --from=devcontainer /app/node_modules/ /app/node_modules/
+COPY --from=devcontainer /app/dist/ /app/dist/
+
+# Required for prisma
+COPY --from=devcontainer /app/libraries/ /app/libraries/
+
+COPY package.json nx.json /app/
+
+VOLUME /config
+VOLUME /uploads
+
+LABEL org.opencontainers.image.title="Postiz App (Devlooper)"

--- a/var/docker/docker-build.sh
+++ b/var/docker/docker-build.sh
@@ -5,3 +5,5 @@ set -o xtrace
 docker rmi localhost/postiz || true
 docker build --target dist -t localhost/postiz -f Dockerfile.dev .
 docker build --target devcontainer -t localhost/postiz-devcontainer -f Dockerfile.dev .
+docker build --target modal -t localhost/postiz-modal -f Dockerfile.dev .
+docker build --target devlooper -t localhost/postiz-devlooper -f Dockerfile.dev .

--- a/var/docker/docker-create.sh
+++ b/var/docker/docker-create.sh
@@ -3,3 +3,11 @@
 docker kill postiz || true 
 docker rm postiz || true 
 docker create --name postiz -p 3000:3000 -p 4200:4200 localhost/postiz
+
+docker kill postiz-modal || true 
+docker rm postiz-modal || true 
+docker create --name postiz-modal -p 3000:3000 -p 4200:4200 localhost/postiz-modal
+
+docker kill postiz-devlooper || true 
+docker rm postiz-devlooper || true 
+docker create --name postiz-devlooper -p 3000:3000 -p 4200:4200 localhost/postiz-devlooper


### PR DESCRIPTION
Add build and create targets for modal and devlooper containers.

* **`var/docker/docker-build.sh`**
  - Add build targets for modal and devlooper containers.
* **`var/docker/docker-create.sh`**
  - Add create commands for modal and devlooper containers.
* **`Dockerfile.dev`**
  - Add new stages for modal and devlooper containers.
* **`.github/workflows/build-containers.yml`**
  - Add jobs for building modal and devlooper containers.
* **`.github/workflows/build-containers-enterprise.yml`**
  - Add jobs for building modal and devlooper containers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sosloan/postiz-app/pull/4?shareId=1fb2d894-2a1f-47a2-9d8d-8bc5346cacd0).